### PR TITLE
修复mysql的bug，增加说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # disconf-docker
+
+使用方法：
+
+```
+docker-compose up
+```
+
+docker-compose安装方式请见：[https://docs.docker.com/compose/install/#master-builds](https://docs.docker.com/compose/install/#master-builds)
+
+完全启动之后，访问ip:9999，使用账号admin，密码admin登录进入disconf管理界面。

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mysql:
-    image: mysql
+    image: mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: 'tuda@123'
     volumes:


### PR DESCRIPTION
1. 纠正无法登陆的bug（mysql8以后的版本修改了客户端认证方式，故登陆会报错，现在docker-compose中将mysql版本改为5.7）

2. 增加一些启动说明，方便后面的人使用